### PR TITLE
Adiciona configuração para desenvolvimento usando docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:10-alpine
+
+WORKDIR /app/client
+
+COPY package* ./
+
+RUN npm install
+
+EXPOSE 4200
+
+CMD npm run start

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Inteligência de dados para ação cidadã.
 * node 10.15.x
 * [angular cli](https://github.com/angular/angular-cli) 8.3.15
 
-## Como desenvolver
+## Como desenvolver (sem )
 
 Primeiro, instale as dependências do projeto com `npm install`.
 
@@ -21,3 +21,46 @@ O comando `npm run build` irá preparar o aplicativo para implantação no servi
 
 O comando `npm run test` executa testes de unidade via [Karma](https://karma-runner.github.io).
 O comando `npm run e2e` executa testes de integração via [Protractor](http://www.protractortest.org/).
+
+## Usando docker
+
+Para iniciar o desenvolvimento do projeto com docker basta levantar o serviço do frontend:
+
+```
+docker-compose up
+```
+
+**Observação importante**
+Sempre que uma nova dependência for adicionada ao projeto é preciso refazer o build da imagem com o node. Para isto basta executar:
+
+Lembre-se de parar o serviço em execução: `docker stop parlametria_frontend_1` ou `docker stop <id_container>`. <id_container> pode ser obtido pelo comando `docker ps`.
+
+```
+docker-compose build
+```
+
+## Comandos úteis
+
+Caso você queira parar os containers e remover os volumes execute:
+
+```
+docker-compose down --volumes
+```
+
+Para visualizar os containers em execução:
+
+```
+docker ps
+```
+
+Para executar comandos num shell dentro do container:
+
+```
+docker exec -it <id_container> sh
+```
+
+Para remover um container
+
+```
+docker rm <id_container>
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.5'
+
+services:
+
+  frontend:
+    build: .
+    volumes:
+      - ./:/app/client
+      - /app/client/node_modules/      
+    ports:
+      - "4200:4200"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",
-    "start": "ng serve",
+    "start": "ng serve --host 0.0.0.0",
     "build": "ng build",
     "test": "ng test",
     "lint": "ng lint",


### PR DESCRIPTION
## Mudanças
- Adiciona configuração usando docker e docker-compose para permitir criação de ambiente de desenvolvimento.

## Avisos
Para iniciar o desenvolvimento com docker execute:
```
docker-compose up
```
Mais instruções de execução no README adicionado por este PR