### PR TITLE
Adiciona configuração do workflow para o github actions

### DIFF
--- a/.github/workflows/parlametria-workflow.yml
+++ b/.github/workflows/parlametria-workflow.yml
@@ -1,0 +1,17 @@
+name: Build
+
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10.x
+      - run: npm install
+      - run: npm run build
+      - run: npm run lint


### PR DESCRIPTION
## Mudanças
- Adiciona configuração do workflow para o github actions

## Avisos
- É necessários estar em um repositório com o [Github Actions](https://github.com/features/actions) habilitado.
- O workflow executa apenas em Pull Requests

Exemplo de execução: https://github.com/gileadekelvin/Parlametria/commit/a2654c878ccd42cfa484f562d7d9f0e725bfedb1/checks?check_suite_id=297219387